### PR TITLE
Create release.yml for automated Release Notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,39 +5,42 @@ changelog:
         - "breaking change"
         - "api change"
         - "deprecation"
+    - title: Security Updates
+      labels:
+        - "security"
     - title: Exciting New Features 🎉
       labels:
         - "enhancement"
         - "new functionality"
         - "new feature"
+    - title: Regression Fixes
+      labels:
+        - "regression"
+    - title: Bug Fixes
+      labels:
+        - "bug"
     - title: Efficiency Improvements
       labels:
         - "efficiency"
-    - title: Documentation Updates
+    - title: Installation Updates
       labels:
-        - "documentation"
+        - "installation"
+    - title: Real-time Processing Improvements
+      labels:
+        - "real-time processing"
     - title: Code Formatting / Style / Refactoring Updates
       labels:
         - "formatting"
         - "refactor"
-    - title: Security Updates
-      labels:
-        - "security"
     - title: Git Workflow Improvements
       labels:
         - "git workflow"
-    - title: Real-time Processing Improvements
-      labels:
-        - "real-time processing"
-    - title: Installation Updates
-      labels:
-        - "installation"
     - title: Testing Updates
       labels:
         - "testing"
-    - title: Bug Fixes
+    - title: Documentation Updates
       labels:
-        - "bug"
+        - "documentation"
     - title: Changes During Release Process
       labels:
         - "Version Release"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,49 @@
+changelog:
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - "breaking change"
+        - "api change"
+        - "deprecation"
+    - title: Exciting New Features 🎉
+      labels:
+        - "enhancement"
+        - "new functionality"
+        - "new feature"
+    - title: Efficiency Improvements
+      labels:
+        - "efficiency"
+    - title: Documentation Updates
+      labels:
+        - "documentation"
+    - title: Code Formatting / Style / Refactoring Updates
+      labels:
+        - "formatting"
+        - "refactor"
+    - title: Security Updates
+      labels:
+        - "security"
+    - title: Git Workflow Improvements
+      labels:
+        - "git workflow"
+    - title: Real-time Processing Improvements
+      labels:
+        - "real-time processing"
+    - title: Installation Updates
+      labels:
+        - "installation"
+    - title: Testing Updates
+      labels:
+        - "testing"
+    - title: Bug Fixes
+      labels:
+        - "bug"
+    - title: Changes During Release Process
+      labels:
+        - "Version Release"
+    - title: Developmental Updates
+      labels:
+        - "Dev Update"
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
release.yml provides the layout for categorizing PRs into different categories in the Release Notes during a github release/tag.
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes


The version of release.yml in this .github repository will be treated as the "master" release.yml file - this does not propagate across repositories, so must be added to each repository where we desire to have the automated release notes during the github release process.